### PR TITLE
Fix incorrect GitHub repository reference. :-)

### DIFF
--- a/adafruit_dymoscale.py
+++ b/adafruit_dymoscale.py
@@ -46,7 +46,7 @@ GRAMS = const(0x02)    # data in weight is in grams
 PULSE_WIDTH = 72.5
 
 __version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_scale.git"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DymoScale.git"
 
 # pylint: disable=too-few-public-methods
 class ScaleReading:


### PR DESCRIPTION
What the title says. Needed so `circup` works properly with this module (see https://github.com/ntoll/circup).

If you've any questions, just ask..! Thanks!

cc/@ladyada