### PR TITLE
Update README to reflect library is unsupported on embedded linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ Introduction
 
 CircuitPython interface for `DYMO <http://www.dymo.com/en-US>`_ postage scales.
 
+NOTE: This library will not work on embedded linux, only on microcontrollers.
 
 Dependencies
 =============


### PR DESCRIPTION
Update to README to reflect library is unsupported on embedded linux
https://github.com/adafruit/Adafruit_CircuitPython_DymoScale/issues/5